### PR TITLE
Use cascade in relations to insert multiple related entities at once

### DIFF
--- a/src/entities/Bed.ts
+++ b/src/entities/Bed.ts
@@ -33,8 +33,13 @@ export class Bed extends BaseEntity {
   @Column()
   gardenId: number
 
+  // Cascade here means that if there is a Garden passed to bed,
+  // a new garden will be inserted
   @Field(() => Garden)
-  @ManyToOne(() => Garden, (garden) => garden.beds, { onDelete: 'CASCADE' })
+  @ManyToOne(() => Garden, (garden) => garden.beds, {
+    cascade: true,
+    onDelete: 'CASCADE',
+  })
   garden: Garden
 
   @Field()

--- a/src/entities/Garden.ts
+++ b/src/entities/Garden.ts
@@ -35,8 +35,12 @@ export class Garden extends BaseEntity {
   @Column()
   ownerId: number
 
+  // cascade means that a new user will be created if passed to user
   @Field(() => User)
-  @ManyToOne(() => User, (owner) => owner.gardens, { onDelete: 'CASCADE' })
+  @ManyToOne(() => User, (owner) => owner.gardens, {
+    cascade: true,
+    onDelete: 'CASCADE',
+  })
   owner: User
 
   @OneToMany(() => Bed, (bed) => bed.garden)

--- a/tests/entities/Bed.test.ts
+++ b/tests/entities/Bed.test.ts
@@ -1,8 +1,8 @@
 import { Connection } from 'typeorm'
 import {
   createBedInDatabase,
-  createGardenInDatabase,
-  createUserInDatabase,
+  createGarden,
+  createUser,
   testConnection,
 } from '../testUtils'
 import { Bed, Garden, User } from '../../src/entities'
@@ -14,8 +14,8 @@ let bed: Bed
 
 beforeAll(async () => {
   connection = await testConnection()
-  owner = await createUserInDatabase()
-  garden = await createGardenInDatabase(owner)
+  owner = createUser()
+  garden = createGarden(owner)
   bed = await createBedInDatabase(garden)
 })
 
@@ -44,7 +44,7 @@ it('should have propery types of the expected type', () => {
   expect(typeof bed.name).toBe('string')
   expect(bed.endedAt instanceof Date).toBe(true)
   expect(typeof bed.isActive).toBe('boolean')
-  expect(bed.gardenId).toEqual(garden.id)
+  expect(Number.isInteger(bed.gardenId)).toBe(true)
   expect(bed.createdAt instanceof Date).toBe(true)
   expect(bed.updatedAt instanceof Date).toBe(true)
 })

--- a/tests/resolvers/Bed.test.ts
+++ b/tests/resolvers/Bed.test.ts
@@ -4,8 +4,8 @@ import jwt from '../../src/utils/jwt'
 import {
   callGraphQL,
   createBedInDatabase,
-  createGardenInDatabase,
-  createUserInDatabase,
+  createGarden,
+  createUser,
   testConnection,
 } from '../testUtils'
 import { Bed, Garden, User } from '../../src/entities'
@@ -18,10 +18,10 @@ let token: string
 
 beforeAll(async () => {
   connection = await testConnection()
-  owner = await createUserInDatabase()
-  garden = await createGardenInDatabase(owner)
+  owner = createUser()
+  garden = createGarden(owner)
   bed = await createBedInDatabase(garden)
-  token = jwt.assign(owner.id.toString())
+  token = jwt.assign(bed.gardenId.toString())
 })
 
 afterAll(async () => {
@@ -105,7 +105,7 @@ describe('the createBed mutation', () => {
 
   beforeAll(async () => {
     name = faker.commerce.productName()
-    gardenId = garden.id
+    gardenId = bed.gardenId
 
     response = await callGraphQL({
       source: createBedMutation,

--- a/tests/resolvers/Garden.test.ts
+++ b/tests/resolvers/Garden.test.ts
@@ -4,7 +4,7 @@ import jwt from '../../src/utils/jwt'
 import {
   callGraphQL,
   createGardenInDatabase,
-  createUserInDatabase,
+  createUser,
   testConnection,
 } from '../testUtils'
 import { Garden, User } from '../../src/entities'
@@ -16,9 +16,9 @@ let owner: User
 
 beforeAll(async () => {
   connection = await testConnection()
-  owner = await createUserInDatabase()
+  owner = createUser()
   garden = await createGardenInDatabase(owner, 'Default Garden')
-  token = jwt.assign(owner.id.toString())
+  token = jwt.assign(garden.ownerId.toString())
 })
 
 afterAll(async () => {

--- a/tests/testUtils/createGarden.ts
+++ b/tests/testUtils/createGarden.ts
@@ -1,0 +1,13 @@
+import faker from 'faker'
+import { Garden, User } from '../../src/entities'
+
+export function createGarden(
+  owner: User,
+  name: string = faker.commerce.productName()
+): Garden {
+  const garden = Garden.create({
+    name,
+    owner,
+  })
+  return garden
+}

--- a/tests/testUtils/createUser.ts
+++ b/tests/testUtils/createUser.ts
@@ -1,0 +1,12 @@
+import faker from 'faker'
+import { User } from '../../src/entities'
+
+export function createUser(): User {
+  const user = User.create({
+    email: faker.internet.email(),
+    password: faker.internet.password(),
+    firstName: faker.name.firstName(),
+    lastName: faker.name.lastName(),
+  })
+  return user
+}

--- a/tests/testUtils/index.ts
+++ b/tests/testUtils/index.ts
@@ -1,5 +1,7 @@
 export * from './callGraphQL'
 export * from './testConnection'
 export * from './createBedInDatabase'
+export * from './createGarden'
 export * from './createGardenInDatabase'
+export * from './createUser'
 export * from './createUserInDatabase'


### PR DESCRIPTION
Added cascade to relations in `entities` files, so that if a parent object is passed on object creation and the object is saved, the parent will be saved as well. Updated tests to save once (with ancestors passed) rather than a chain of object creation and save statements.

Closes #21 